### PR TITLE
Update Docker configuration and add nginx default configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN wget https://wordpress.org/latest.zip && \
   mv wordpress /var/www/html/ && \
   chown -R www-data:www-data /var/www/html/wordpress
 COPY conf/wp-config.php /var/www/html/wordpress/
-COPY conf/000-default.conf /etc/nginx/sites-available/
-RUN ln -s /etc/nginx/sites-available/000-default.conf /etc/nginx/sites-enabled/
+COPY conf/000-default.conf /etc/apache2/sites-available/
+RUN ln -s /etc/apache2/sites-available/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 RUN chmod -R 755 /var/www/html/wordpress
 
 WORKDIR /var/www/html/wordpress

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ RUN wget https://wordpress.org/latest.zip && \
   mv wordpress /var/www/html/ && \
   chown -R www-data:www-data /var/www/html/wordpress
 COPY conf/wp-config.php /var/www/html/wordpress/
-RUN chmod -R 755 /var/www/html/wordpress
+COPY conf/000-default.conf /etc/nginx/sites-available/
+RUN ln -s /etc/nginx/sites-available/000-default.conf
+RUN chmod -R 755 /var/www/html/wordpress /etc/nginx/sites-enabled/
+
+WORKDIR /var/www/html/wordpress
 
 # Configurez Apache pour servir votre site WordPress
 RUN echo '\n<Directory /var/www/html/wordpress/>\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,10 @@ RUN wget https://wordpress.org/latest.zip && \
   chown -R www-data:www-data /var/www/html/wordpress
 COPY conf/wp-config.php /var/www/html/wordpress/
 COPY conf/000-default.conf /etc/apache2/sites-available/
-RUN ln -s /etc/apache2/sites-available/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 RUN chmod -R 755 /var/www/html/wordpress
 
 WORKDIR /var/www/html/wordpress
 
-# Configurez Apache pour servir votre site WordPress
-RUN echo '\n<Directory /var/www/html/wordpress/>\n\
-    AllowOverride All\n\
-</Directory>\n' >> /etc/apache2/sites-available/000-default.conf
 RUN a2enmod rewrite
 
 # Exposez le port 80 pour le serveur web

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ RUN wget https://wordpress.org/latest.zip && \
   mv wordpress /var/www/html/ && \
   chown -R www-data:www-data /var/www/html/wordpress
 COPY conf/wp-config.php /var/www/html/wordpress/
+COPY conf/000-default.conf /etc/nginx/sites-available/
+RUN ln -s /etc/nginx/sites-available/000-default.conf /etc/nginx/sites-enabled/
 RUN chmod -R 755 /var/www/html/wordpress
+
+WORKDIR /var/www/html/wordpress
 
 # Configurez Apache pour servir votre site WordPress
 RUN echo '\n<Directory /var/www/html/wordpress/>\n\

--- a/conf/000-default.conf
+++ b/conf/000-default.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html/wordpress
+
+    <Directory /var/www/html/wordpress>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>


### PR DESCRIPTION
The Dockerfile has been updated to include a new default configuration file for nginx. A symlink to this file has also been created in the nginx 'sites-available' directory. This allows nginx to serve the WordPress installation, previously located at /var/www/html/wordpress. The work directory in Docker has also been updated to this path.